### PR TITLE
Update Reth image and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ NETWORK_PRIVATE_KEY="PRIVATE_KEY" to the SP1 prover network private key from Cel
     cp .env.example .env
     ```
 
+1. Run sp1up
+
+    ```shell
+    sp1up
+    ```
+
 1. Install contract dependencies and the SP1 Tendermint light client operator binary from solidity-ibc-eureka.
 
     ```shell
@@ -60,7 +66,17 @@ NETWORK_PRIVATE_KEY="PRIVATE_KEY" to the SP1 prover network private key from Cel
     make build-simapp-docker
     ```
 
-1. Run the demo
+1. Copy the proto_description.bin file one directory up in celestia prover
+    ```shell
+    cp ./provers/celestia-prover/prover/proto_descriptor.bin ./provers/celestia-prover/
+    ```
+
+1. Run the Celestia prover
+    ```shell
+    cargo run --package celestia-prover
+    ```
+
+1. Run the demo in a different terminal window
 
     ```shell
     # This runs make start, setup, and transfer

--- a/docker-compose.rollkit.yml
+++ b/docker-compose.rollkit.yml
@@ -18,7 +18,7 @@ services:
       - rollkit-network
 
   reth:
-    image: ghcr.io/paradigmxyz/reth # Use the official Reth image
+    image: ghcr.io/paradigmxyz/reth:v1.3.11 # Use the official Reth image
     container_name: reth
     ports:
       - "30303:30303" # P2P port


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Found that the latest reth version does not supports the rpc.eth-proof-window flag. Pins the Reth version to use a specific version that supports it.

Updated README.md with some additional commands needed for the setup.

Ran everything locally to test.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
