### PR TITLE
chore: add celestia bridge node to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 services:
   celestia-init:
-    image: ghcr.io/celestiaorg/celestia-app-standalone:02ff9af
+    image: ghcr.io/celestiaorg/celestia-app-standalone:feature-zk-execution-ism
     container_name: celestia-init
     entrypoint: /scripts/init.sh
     volumes:
       - ./scripts/init-celestia.sh:/scripts/init.sh:ro
-      - celestia-app:/home/celestia/.celestia-appd
+      - celestia-app:/home/celestia/.celestia-app
     restart: "no"
 
   celestia-validator:
-    image: ghcr.io/celestiaorg/celestia-app-standalone:02ff9af
+    image: ghcr.io/celestiaorg/celestia-app-standalone:feature-zk-execution-ism
     container_name: celestia-validator
     ports:
       - "26656:26656"
@@ -18,13 +18,13 @@ services:
     healthcheck:
       test: [
         "CMD-SHELL",
-        "bh=$(curl -sf http://localhost:26657/status | jq -r '.result.sync_info.latest_block_height'); if [ \"$$bh\" -ge 1 ]; then exit 0; else exit 1; fi"
+        "bh=$(curl -sf http://localhost:26657/status | jq -r '.result.sync_info.latest_block_height'); if [ \"$$bh\" -gt 1 ]; then exit 0; else exit 1; fi"
       ]
       interval: 30s
       timeout: 5s
       start_period: 10s
     volumes:
-      - celestia-app:/home/celestia/.celestia-appd
+      - celestia-app:/home/celestia/.celestia-app
     command: >
       start --force-no-bbr
     depends_on:
@@ -33,8 +33,26 @@ services:
     networks:
       - celestia-zkevm-net
 
+  celestia-bridge:
+    image: ghcr.io/celestiaorg/celestia-node:v0.23.0-rc0
+    container_name: celestia-bridge
+    volumes:
+      - ./scripts/init-celestia-bridge.sh:/scripts/init.sh:ro
+      - celestia-bridge:/home/celestia
+    entrypoint: /scripts/init.sh
+    command: celestia bridge start --log.level.module share/discovery:fatal
+    ports:
+      - "26658:26658"
+      - "2121:2121"
+    depends_on:
+      celestia-validator:
+        condition: service_healthy
+    networks:
+      - celestia-zkevm-net
+
 volumes:
   celestia-app:
+  celestia-bridge:
 
 networks:
   celestia-zkevm-net:

--- a/scripts/init-celestia-bridge.sh
+++ b/scripts/init-celestia-bridge.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CHAIN_ID="celestia-zkevm-testnet"
+CONSENSUS_RPC="http://celestia-validator:26657/status"
+
+if [ -f /home/celestia/.env ]; then
+    echo "Skipping initialisation..."
+    source /home/celestia/.env
+
+    echo $CELESTIA_CUSTOM
+else
+    echo "Fetching genesis block hash at $CONSENSUS_RPC..."
+    GEN_BLOCK_HASH=$(curl -sf "$CONSENSUS_RPC" | jq -r '.result.sync_info.earliest_block_hash')
+
+    if [[ "$GEN_BLOCK_HASH" == "null" || -z "$GEN_BLOCK_HASH" ]]; then
+        echo "Could not retrieve a valid genesis block hash from $CONSENSUS_RPC"
+        exit 1
+    fi
+
+    echo "Exporting env CELESTIA_CUSTOM=$CHAIN_ID:$GEN_BLOCK_HASH"
+    export CELESTIA_CUSTOM="$CHAIN_ID:$GEN_BLOCK_HASH"
+    echo "export CELESTIA_CUSTOM=$CELESTIA_CUSTOM" > /home/celestia/.env
+
+    echo "Initializing bridge node..."
+    celestia bridge init \
+        --core.ip celestia-validator \
+        --rpc.addr 0.0.0.0 \
+        --rpc.port 26658
+fi
+
+echo "Starting bridge node..."
+exec "$@"


### PR DESCRIPTION
## Overview

- Adds celestia bridge node (v0.23.0-rc0) with v4 support to new docker compose setup.
- Updates celestia-app image to `ghcr.io/celestiaorg/celestia-app-standalone:feature-zk-execution-ism` and removes workarounds for genesis.json

Note, will later extend this setup if a specific account or token is required for the rollup to use the DA layer