### PR TITLE
fix: allow rollkit restarts without tearing down volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,10 @@ services:
   rollkit-evm-single:
     image: ghcr.io/rollkit/rollkit-evm-single:v0.1.3
     container_name: rollkit-evm-single
-    entrypoint: /usr/bin/entrypoint.sh
+    volumes:
+      - ./testnet/rollkit-evm-single/init.sh:/scripts/init.sh:ro
+      - rollkit:/root/.evm-single
+    entrypoint: /scripts/init.sh
     environment:
       - EVM_ENGINE_URL=http://reth:8551
       - EVM_ETH_URL=http://reth:8545
@@ -110,10 +113,12 @@ services:
     networks:
       - celestia-zkevm-net
 
+
 volumes:
   celestia-app:
   celestia-bridge:
   reth:
+  rollkit:
 
 networks:
   celestia-zkevm-net:

--- a/testnet/rollkit-evm-single/init.sh
+++ b/testnet/rollkit-evm-single/init.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Adpated from: https://github.com/rollkit/rollkit/blob/main/rollups/evm/single/entrypoint.sh
+
+set -e
+
+SIGNER_FILE="/root/.evm-single/config/signer.json"
+
+cd /usr/bin
+sleep 5
+
+# Conditionally add --rollkit.da.address if ROLLKIT_DA_ADDRESS is set
+da_flag=""
+if [ -n "$DA_ADDRESS" ]; then
+da_flag="--rollkit.da.address $DA_ADDRESS"
+fi
+
+# Conditionally add --rollkit.da.auth_token if ROLLKIT_DA_AUTH_TOKEN is set
+da_auth_token_flag=""
+if [ -n "$DA_AUTH_TOKEN" ]; then
+da_auth_token_flag="--rollkit.da.auth_token $DA_AUTH_TOKEN"
+fi
+
+# Conditionally add --rollkit.da.namespace if ROLLKIT_DA_NAMESPACE is set
+da_namespace_flag=""
+if [ -n "$DA_NAMESPACE" ]; then
+da_namespace_flag="--rollkit.da.namespace $DA_NAMESPACE"
+fi
+
+if [[ ! -f "$SIGNER_FILE" ]]; then
+    echo "Initialising rollkit-evm-single..."
+
+    ./evm-single init --rollkit.node.aggregator=true --rollkit.signer.passphrase $EVM_SIGNER_PASSPHRASE
+fi
+
+echo "Starting rollkit-evm-single..."
+
+exec ./evm-single start \
+--evm.jwt-secret $EVM_JWT_SECRET \
+--evm.genesis-hash $EVM_GENESIS_HASH \
+--evm.engine-url $EVM_ENGINE_URL \
+--evm.eth-url $EVM_ETH_URL \
+--rollkit.node.block_time $EVM_BLOCK_TIME \
+--rollkit.node.aggregator=true \
+--rollkit.signer.passphrase $EVM_SIGNER_PASSPHRASE \
+$da_flag \
+$da_auth_token_flag \
+$da_namespace_flag 


### PR DESCRIPTION
## Overview

Should allow `rollkit-evm-single` service to restart cleanly.

As a user of the docker compose services I would like to stop the services running on my machine and restart them while preserving the existing chain state. Right now we are blocked on achieving this only by the rollkit-evm-single service.

closes: #50