### PR TITLE
chore: add temporary local relayer binary and make target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 /target
 *.bin
 bin
+
+**/hyperlane_db

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,12 @@ start:
 	@docker compose up --detach
 .PHONY: start
 
+## relay-local: Start a local instance of the hyperlane relayer (NOTE: This is temporary and should be removed in favour of Docker).
+relay-local:
+	@echo "--> Starting hyperlane relayer"
+	@cd local && CONFIG_FILES=./config/config.json ./relayer
+.PHONY: relay-local
+
 ## setup: Set up the IBC light clients.
 setup:
 	@echo "--> Creating genesis.json for Tendermint light client"

--- a/local/config/config.json
+++ b/local/config/config.json
@@ -1,0 +1,106 @@
+{
+    "chains": {
+        "rethlocal": {
+            "blocks": {
+                "confirmations": 1,
+                "estimateBlockTime": 3,
+                "reorgPeriod": 0
+            },
+            "chainId": 1234,
+            "displayName": "Reth",
+            "domainId": 1234,
+            "isTestnet": true,
+            "name": "rethlocal",
+            "nativeToken": {
+                "decimals": 18,
+                "name": "Ether",
+                "symbol": "ETH"
+            },
+            "protocol": "ethereum",
+            "rpcUrls": [
+                {
+                    "http": "http://127.0.0.1:8545"
+                }
+            ],
+            "signer": {
+                "type": "hexKey",
+                "key": "0x82bfcfadbf1712f6550d8d2c00a39f05b33ec78939d0167be2a737d691f33a6a"
+            },
+            "aggregationHook": "0xe53275A1FcA119e1c5eeB32E7a72e54835A63936",
+            "domainRoutingIsm": "0xE2c1756b8825C54638f98425c113b51730cc47f6",
+            "fallbackRoutingHook": "0xE2c1756b8825C54638f98425c113b51730cc47f6",
+            "interchainGasPaymaster": "0x1D957dA7A6988f5a9d2D2454637B4B7fea0Aeea5",
+            "interchainSecurityModule": "0xa05915fD6E32A1AA7E67d800164CaCB12487142d",
+            "mailbox": "0xb1c938F5BA4B3593377F399e12175e8db0C787Ff",
+            "merkleTreeHook": "0xFCb1d485ef46344029D9E8A7925925e146B3430E",
+            "protocolFee": "0x8A93d247134d91e0de6f96547cB0204e5BE8e5D8",
+            "proxyAdmin": "0x7e7aD18Adc99b94d4c728fDf13D4dE97B926A0D8",
+            "storageGasOracle": "0x457cCf29090fe5A24c19c1bc95F492168C0EaFdb",
+            "testRecipient": "0xd7958B336f0019081Ad2279B2B7B7c3f744Bce0a",
+            "validatorAnnounce": "0x79ec7bF05AF122D3782934d4Fb94eE32f0C01c97"
+        },
+        "celestia": {
+            "bech32Prefix": "celestia",
+            "blocks": {
+                "confirmations": 1,
+                "estimateBlockTime": 6,
+                "reorgPeriod": 1
+            },
+            "canonicalAsset": "utia",
+            "chainId": "celestia-zkevm-testnet",
+            "contractAddressBytes": 32,
+            "deployer": {
+                "name": "Damian",
+                "url": "https://github.com/damiannolan"
+            },
+            "displayName": "Celestia ZKEVM Testnet",
+            "domainId": 69420,
+            "gasPrice": {
+                "denom": "utia",
+                "amount": "0.002"
+            },
+            "index": {
+                "from": 1150,
+                "chunk": 10
+            },
+            "isTestnet": true,
+            "name": "celestia",
+            "nativeToken": {
+                "decimals": 6,
+                "denom": "utia",
+                "name": "TIA",
+                "symbol": "TIA"
+            },
+            "protocol": "cosmosnative",
+            "restUrls": [
+                {
+                    "http": "http://127.0.0.1:1317"
+                }
+            ],
+            "rpcUrls": [
+                {
+                    "http": "http://127.0.0.1:26657"
+                }
+            ],
+            "signer": {
+                "type": "cosmosKey",
+                "key": "0x748bcf364b62ac9b74c2bc13e2d429c5b85a3b3ddd8089b873369c1e38fcb10e",
+                "prefix": "celestia"
+            },
+            "slip44": 118,
+            "technicalStack": "other",
+            "interchainSecurityModule": "0x726f757465725f69736d00000000000000000000000000000000000000000000",
+            "mailbox": "0x68797065726c616e650000000000000000000000000000000000000000000000",
+            "interchainGasPaymaster": "0x726f757465725f706f73745f6469737061746368000000000000000000000000",
+            "merkleTreeHook": "0x726f757465725f706f73745f6469737061746368000000030000000000000001",
+            "validatorAnnounce": "0x68797065726c616e650000000000000000000000000000000000000000000000",
+            "grpcUrls": [
+                {
+                    "http": "http://127.0.0.1:9090"
+                }
+            ]
+        }
+    },
+    "defaultRpcConsensusType": "fallback",
+    "relayChains": "rethlocal,celestia"
+}


### PR DESCRIPTION
## Overview

We can temporarily rely on this local relayer to get the job done. 
I've checked in a binary I built from hyperlane-monorepo@main last week. 

The binary does appear to be a little bit large (~81mb).
If we'd prefer to just provide a commit and instructions to compile the binary we can do that. I am indifferent.