### PR TITLE
chore: address follow ups in evm-exec program

### DIFF
--- a/crates/sp1/evm-exec/script/src/bin/main.rs
+++ b/crates/sp1/evm-exec/script/src/bin/main.rs
@@ -21,7 +21,7 @@ use clap::Parser;
 use eq_common::KeccakInclusionToDataRootProofInput;
 use evm_exec_types::EvmBlockExecOutput;
 use nmt_rs::{simple_merkle::proof::Proof, TmSha2Hasher};
-use rsp_client_executor::io::{EthClientExecutorInput, WitnessInput};
+use rsp_client_executor::io::EthClientExecutorInput;
 use sp1_sdk::{include_elf, ProverClient, SP1ProofWithPublicValues, SP1Stdin};
 use tendermint::block::header::Header;
 


### PR DESCRIPTION
## Overview

- Remove proto encoded data root from inputs.
  - Use the data root from the `blob_proof` input instead. 
- Remove unnecessary trusted state root assertion. Commit to the state anchor (parent state root)

closes: #66 