### PR TITLE
feat: add program prover trait and skeleton implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,12 +2674,14 @@ version = "0.1.0"
 dependencies = [
  "alloy-provider",
  "anyhow",
+ "async-trait",
  "bincode",
  "celestia-rpc",
  "celestia-types",
  "clap",
  "dirs",
  "eq-common",
+ "nmt-rs",
  "prost 0.12.6",
  "prost-build 0.12.6",
  "reqwest",
@@ -2689,14 +2691,10 @@ dependencies = [
  "rsp-rpc-db",
  "serde",
  "serde_yaml",
-<<<<<<< HEAD
+ "sha3",
  "sp1-build",
  "sp1-sdk",
-=======
- "sha3",
- "sp1-sdk",
  "tendermint",
->>>>>>> 352431d (feat(wip): begin block prover impl)
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,15 +2672,31 @@ dependencies = [
 name = "evm-prover"
 version = "0.1.0"
 dependencies = [
+ "alloy-provider",
  "anyhow",
+ "bincode",
+ "celestia-rpc",
+ "celestia-types",
  "clap",
  "dirs",
+ "eq-common",
  "prost 0.12.6",
  "prost-build 0.12.6",
+ "reqwest",
+ "reth-chainspec 1.3.2",
+ "rsp-host-executor",
+ "rsp-primitives",
+ "rsp-rpc-db",
  "serde",
  "serde_yaml",
+<<<<<<< HEAD
  "sp1-build",
  "sp1-sdk",
+=======
+ "sha3",
+ "sp1-sdk",
+ "tendermint",
+>>>>>>> 352431d (feat(wip): begin block prover impl)
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ eq-common = "0.1.4"
 ethers = { version = "2.0", features = ["ws", "rustls"] }
 hex = "0.4.3"
 nmt-rs = "*"
+reqwest = "0.12.20"
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.3", default-features = false }
 reth-primitives = { git = "https://github.com/sp1-patches/reth", tag = "rsp-20240830", default-features = false, features = [
     "alloy-compat",

--- a/crates/evm-prover/Cargo.toml
+++ b/crates/evm-prover/Cargo.toml
@@ -12,6 +12,7 @@ walkdir = "2.5.0"
 [dependencies]
 anyhow = "1.0"
 alloy-provider = { workspace = true }
+async-trait = "0.1.88"
 bincode = { workspace = true }
 celestia-types = { workspace = true }
 celestia-rpc = { workspace = true }
@@ -34,4 +35,3 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 tonic = { version = "0.10", features = ["transport"] }
 tonic-reflection = "0.10"
-async-trait = "0.1.88"

--- a/crates/evm-prover/Cargo.toml
+++ b/crates/evm-prover/Cargo.toml
@@ -18,6 +18,7 @@ celestia-rpc = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 eq-common = { workspace = true }
+nmt-rs = { workspace = true }
 prost = "0.12"
 reqwest = { workspace = true }
 reth-chainspec = { workspace = true }
@@ -33,3 +34,4 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 tonic = { version = "0.10", features = ["transport"] }
 tonic-reflection = "0.10"
+async-trait = "0.1.88"

--- a/crates/evm-prover/Cargo.toml
+++ b/crates/evm-prover/Cargo.toml
@@ -11,12 +11,24 @@ walkdir = "2.5.0"
 
 [dependencies]
 anyhow = "1.0"
+alloy-provider = { workspace = true }
+bincode = { workspace = true }
+celestia-types = { workspace = true }
+celestia-rpc = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
+eq-common = { workspace = true }
 prost = "0.12"
+reqwest = { workspace = true }
+reth-chainspec = { workspace = true }
+rsp-host-executor = { workspace = true }
+rsp-primitives = { workspace = true }
+rsp-rpc-db = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = "0.9"
+sha3 = { workspace = true }
 sp1-sdk = { workspace = true }
+tendermint = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 tonic = { version = "0.10", features = ["transport"] }

--- a/crates/evm-prover/src/config/config.rs
+++ b/crates/evm-prover/src/config/config.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use serde::{Deserialize, Serialize};
 
 pub const APP_HOME_DIR: &str = ".evm-prover";
@@ -7,17 +5,13 @@ pub const CONFIG_FILE: &str = "config.yaml";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
-    // the prover service grpc server address
     pub grpc_address: String,
-    // the genesis path for the EVM chain genesis file
-    pub genesis_path: Option<PathBuf>,
 }
 
 impl Config {
     pub fn default() -> Self {
         Self {
             grpc_address: "127.0.0.1:50051".to_string(),
-            genesis_path: Some(PathBuf::from(format!("{}/genesis.json", APP_HOME_DIR))),
         }
     }
 }

--- a/crates/evm-prover/src/config/config.rs
+++ b/crates/evm-prover/src/config/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 
 pub const APP_HOME_DIR: &str = ".evm-prover";
@@ -5,13 +7,17 @@ pub const CONFIG_FILE: &str = "config.yaml";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
+    // the prover service grpc server address
     pub grpc_address: String,
+    // the genesis path for the EVM chain genesis file
+    pub genesis_path: Option<PathBuf>,
 }
 
 impl Config {
     pub fn default() -> Self {
         Self {
             grpc_address: "127.0.0.1:50051".to_string(),
+            genesis_path: Some(PathBuf::from(format!("{}/genesis.json", APP_HOME_DIR))),
         }
     }
 }

--- a/crates/evm-prover/src/prover/prover.rs
+++ b/crates/evm-prover/src/prover/prover.rs
@@ -1,3 +1,16 @@
+use std::sync::Arc;
+
+use alloy_provider::ProviderBuilder;
+use anyhow::Result;
+use celestia_rpc::{BlobClient, Client, HeaderClient, ShareClient};
+use celestia_types::nmt::Namespace;
+use celestia_types::{Blob, Commitment, ExtendedHeader, ShareProof};
+use eq_common::KeccakInclusionToDataRootProofInput;
+use reth_chainspec::ChainSpec;
+use rsp_host_executor::EthHostExecutor;
+use rsp_primitives::genesis::Genesis;
+use rsp_rpc_db::RpcDb;
+use sha3::{Digest, Keccak256};
 use sp1_sdk::include_elf;
 
 /// The ELF (executable and linkable format) file for the Succinct RISC-V zkVM.
@@ -6,4 +19,90 @@ pub const EVM_EXEC_ELF: &[u8] = include_elf!("evm-exec-program");
 /// The ELF (executable and linkable format) file for the Succinct RISC-V zkVM.
 pub const EVM_RANGE_EXEC_ELF: &[u8] = include_elf!("evm-range-exec-program");
 
-pub struct BlockProver {}
+pub struct BlockProver {
+    pub evm_rpc_url: String,
+    pub celestia_rpc_url: String,
+    pub chain_spec: Arc<ChainSpec>,
+    pub genesis: Genesis,
+    pub namespace: Namespace,
+}
+
+impl BlockProver {
+    pub async fn new(
+        evm_rpc_url: String,
+        celestia_rpc_url: String,
+        chain_spec: Arc<ChainSpec>,
+        genesis: Genesis,
+        namespace: Namespace,
+    ) -> Result<Self> {
+        Ok(Self {
+            evm_rpc_url,
+            celestia_rpc_url,
+            chain_spec,
+            genesis,
+            namespace,
+        })
+    }
+
+    pub async fn generate_stf(&self, block_number: u64) -> Result<Vec<u8>> {
+        let host_executor = EthHostExecutor::eth(self.chain_spec.clone(), None);
+        let provider = ProviderBuilder::new().on_http(self.evm_rpc_url.parse()?);
+        let rpc_db = RpcDb::new(provider.clone(), block_number - 1);
+
+        let client_input = host_executor
+            .execute(block_number, &rpc_db, &provider, self.genesis.clone(), None, false)
+            .await?;
+
+        Ok(bincode::serialize(&client_input)?)
+    }
+
+    pub async fn inclusion_height(&self, _block_number: u64) -> Result<(u64, Commitment)> {
+        panic!("TODO(unimplemented): Query rollkit rpc for DA inclusion height");
+    }
+
+    pub async fn blob_inclusion_proof(
+        &self,
+        inclusion_height: u64,
+        commitment: Commitment,
+    ) -> Result<(KeccakInclusionToDataRootProofInput, ExtendedHeader)> {
+        let celestia_client = Client::new(&self.celestia_rpc_url, None).await?;
+
+        let blob = celestia_client
+            .blob_get(inclusion_height, self.namespace, commitment)
+            .await?;
+        let header = celestia_client.header_get_by_height(inclusion_height).await?;
+        let share_proof = self.verify_blob_inclusion(&header, &blob).await?;
+
+        let keccak_hash: [u8; 32] = Keccak256::new().chain_update(&blob.data).finalize().into();
+
+        let input = KeccakInclusionToDataRootProofInput {
+            data: blob.data.clone(),
+            namespace_id: self.namespace,
+            share_proofs: share_proof.share_proofs.clone(),
+            row_proof: share_proof.row_proof.clone(),
+            data_root: header.dah.hash().as_bytes().try_into()?,
+            keccak_hash,
+        };
+
+        Ok((input, header))
+    }
+
+    async fn verify_blob_inclusion(&self, header: &ExtendedHeader, blob: &Blob) -> Result<ShareProof> {
+        let eds_size = header.dah.row_roots().len() as u64;
+        let ods_size = eds_size / 2;
+        let first_row_index = blob.index.unwrap() / eds_size;
+        let ods_index = blob.index.unwrap() - (first_row_index * ods_size);
+
+        let mut header = header.clone();
+        header.header.version.app = 3;
+
+        let celestia_client = Client::new(&self.celestia_rpc_url, None).await?;
+        let range_response = celestia_client
+            .share_get_range(&header, ods_index, ods_index + blob.shares_len() as u64)
+            .await?;
+
+        let share_proof = range_response.proof;
+        share_proof.verify(header.dah.hash())?;
+        Ok(share_proof)
+    }
+}

--- a/crates/evm-prover/src/prover/prover.rs
+++ b/crates/evm-prover/src/prover/prover.rs
@@ -39,7 +39,6 @@ pub trait ProgramProver {
         let cfg = self.cfg();
         let stdin = self.build_stdin(input)?;
 
-        // TODO: cache (pk, vk) in the cfg struct?
         let (pk, _vk) = self.prover().setup(cfg.elf);
 
         let proof: SP1ProofWithPublicValues = match cfg.proof_mode {

--- a/crates/evm-prover/src/prover/service.rs
+++ b/crates/evm-prover/src/prover/service.rs
@@ -1,8 +1,3 @@
-use std::sync::Arc;
-
-use celestia_types::nmt::Namespace;
-use reth_chainspec::ChainSpec;
-use rsp_primitives::genesis::Genesis;
 use tonic::{Request, Response, Status};
 
 use crate::proto::celestia::prover::v1::prover_server::Prover;
@@ -10,7 +5,6 @@ use crate::proto::celestia::prover::v1::{
     InfoRequest, InfoResponse, ProveStateMembershipRequest, ProveStateMembershipResponse, ProveStateTransitionRequest,
     ProveStateTransitionResponse,
 };
-use crate::prover::prover::BlockProver;
 
 #[derive(Default)]
 pub struct ProverService {}

--- a/crates/evm-prover/src/prover/service.rs
+++ b/crates/evm-prover/src/prover/service.rs
@@ -1,10 +1,16 @@
+use std::sync::Arc;
+
+use celestia_types::nmt::Namespace;
+use reth_chainspec::ChainSpec;
+use rsp_primitives::genesis::Genesis;
 use tonic::{Request, Response, Status};
 
 use crate::proto::celestia::prover::v1::prover_server::Prover;
 use crate::proto::celestia::prover::v1::{
-    InfoRequest, InfoResponse, ProveStateMembershipRequest, ProveStateMembershipResponse,
-    ProveStateTransitionRequest, ProveStateTransitionResponse,
+    InfoRequest, InfoResponse, ProveStateMembershipRequest, ProveStateMembershipResponse, ProveStateTransitionRequest,
+    ProveStateTransitionResponse,
 };
+use crate::prover::prover::BlockProver;
 
 #[derive(Default)]
 pub struct ProverService {}
@@ -24,17 +30,13 @@ impl Prover for ProverService {
         &self,
         _request: Request<ProveStateTransitionRequest>,
     ) -> Result<Response<ProveStateTransitionResponse>, Status> {
-        Err(Status::unimplemented(
-            "prove_state_transition is unimplemented",
-        ))
+        Err(Status::unimplemented("prove_state_transition is unimplemented"))
     }
 
     async fn prove_state_membership(
         &self,
         _request: Request<ProveStateMembershipRequest>,
     ) -> Result<Response<ProveStateMembershipResponse>, Status> {
-        Err(Status::unimplemented(
-            "prove_state_membership is unimplemented",
-        ))
+        Err(Status::unimplemented("prove_state_membership is unimplemented"))
     }
 }


### PR DESCRIPTION
## Overview

Part of ref: #65 

This PR adds new trait `ProgramProver` to be implemented per sp1 program within a prover service. 
The trait defines the base functionality which should be implemented for a `ProgramProver`, allowing generic plugging of its `Input` and `Output` structs. This allows us to have separation of concerns with respect to how the prover service interacts with an SP1 program, i.e. not mixing logic such as rpc data retrieval, etc which should be self contained elsewhere.

