### PR TITLE
chore: avoid rate limits in ci by providing github token

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,8 +15,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
## Overview

We are being rate limits in some CI workflow runs due to usage and not provided the Github token of the repo.

> Error: Error: API rate limit exceeded for 20.55.118.193. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
