### PR TITLE
docs: fix typos

### DIFF
--- a/crates/sp1/README.md
+++ b/crates/sp1/README.md
@@ -3,5 +3,5 @@
 This directory contains crates for ZK programs using SP1. 
 
 - `evm-exec` contains an SP1 program for proving EVM block execution and data availability in celestia.
-- `evm-exec-types` contains types used for SP1 program IO such as the set of commited outputs.
+- `evm-exec-types` contains types used for SP1 program IO such as the set of committed outputs.
 - `evm-range-exec` contains an SP1 program which aggregates proofs output by the `evm-exec` program.

--- a/testdata/benchmarks/README.md
+++ b/testdata/benchmarks/README.md
@@ -1,7 +1,7 @@
 ## Benchmarking
 
 The following benchmarks have been created using the `script` crates included in each of the sp1 programs `evm-exec` and `evm-range-exec`.
-Please refer to the `README.md` files in under [sp1/evm-exec](../../crates/sp1/evm-exec/README.md) and [sp1/evm-range-exec](../../crates/sp1/evm-range-exec/README.md) for intructions on how to invoke the SP1 programs.
+Please refer to the `README.md` files in under [sp1/evm-exec](../../crates/sp1/evm-exec/README.md) and [sp1/evm-range-exec](../../crates/sp1/evm-range-exec/README.md) for instructions on how to invoke the SP1 programs.
 
 ### Collecting proof input data
 


### PR DESCRIPTION


This PR corrects two spelling errors in the documentation:

- **`crates/sp1/README.md`**: Fixed "commited" → "committed" 
- **`testdata/benchmarks/README.md`**: Fixed "intructions" → "instructions"

