### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,5 +35,5 @@ If you encounter bugs or have feature suggestions, please [open an issue](https:
 
 Feel free to reach out via:
 
-- [Celestia community chanels](https://celestia.org/community/)
+- [Celestia community channels](https://celestia.org/community/)
 - Issues and Discussions tabs on GitHub

--- a/testdata/benchmarks/BENCHMARKS.md
+++ b/testdata/benchmarks/BENCHMARKS.md
@@ -10,7 +10,7 @@ These are estimates, but should serve as a rough guideline. The last two gas poi
 
 ### Results
 
-⚠️ The `execute EVM blocks` metric is inclusive of all the RSP profiles, i.e. `block execution`, `recover senders`, `initialze witness db`, `compute state root`, `validate block post execution`.
+⚠️ The `execute EVM blocks` metric is inclusive of all the RSP profiles, i.e. `block execution`, `recover senders`, `initialize witness db`, `compute state root`, `validate block post execution`.
  
 #### 15M Gas/s, single DA block
 


### PR DESCRIPTION


- **`docs/CONTRIBUTING.md`**: Fixed typo "chanels" → "channels" in community channels reference
- **`testdata/benchmarks/BENCHMARKS.md`**: 
  - Fixed typo "initialze" → "initialize" in witness database initialization
