### PR TITLE
chore: disallow absence proofs in block prover program

### DIFF
--- a/crates/evm-prover/src/prover/block.rs
+++ b/crates/evm-prover/src/prover/block.rs
@@ -428,7 +428,8 @@ impl BlockExecProver {
         let proofs: Vec<NamespaceProof> = namespace_data
             .rows
             .iter()
-            .filter_map(|row| row.proof.is_of_presence().then(|| row.proof.clone()))
+            .filter(|row| row.proof.is_of_presence())
+            .map(|row| row.proof.clone())
             .collect();
 
         let signed_data: Vec<SignedData> = event

--- a/crates/evm-prover/src/prover/block.rs
+++ b/crates/evm-prover/src/prover/block.rs
@@ -428,8 +428,7 @@ impl BlockExecProver {
         let proofs: Vec<NamespaceProof> = namespace_data
             .rows
             .iter()
-            .filter(|row| row.proof.is_of_presence())
-            .map(|row| row.proof.clone())
+            .filter_map(|row| row.proof.is_of_presence().then(|| row.proof.clone()))
             .collect();
 
         let signed_data: Vec<SignedData> = event

--- a/crates/evm-prover/src/prover/block.rs
+++ b/crates/evm-prover/src/prover/block.rs
@@ -425,7 +425,12 @@ impl BlockExecProver {
             .share_get_namespace_data(&header_clone, self.app.namespace)
             .await?;
 
-        let proofs: Vec<NamespaceProof> = namespace_data.rows.iter().map(|row| row.proof.clone()).collect();
+        let proofs: Vec<NamespaceProof> = namespace_data
+            .rows
+            .iter()
+            .filter(|row| row.proof.is_of_presence())
+            .map(|row| row.proof.clone())
+            .collect();
 
         let signed_data: Vec<SignedData> = event
             .blobs

--- a/crates/sp1/evm-exec/program/src/main.rs
+++ b/crates/sp1/evm-exec/program/src/main.rs
@@ -106,6 +106,8 @@ pub fn main() {
 
     let mut cursor = 0;
     for (proof, root) in inputs.proofs.iter().zip(roots) {
+        assert!(proof.is_of_presence(), "NamespaceProof must be of presence");
+
         let share_count = (proof.end_idx() - proof.start_idx()) as usize;
         let end = cursor + share_count;
 

--- a/crates/sp1/evm-exec/script/src/bin/datagen.rs
+++ b/crates/sp1/evm-exec/script/src/bin/datagen.rs
@@ -137,7 +137,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         let mut proofs: Vec<NamespaceProof> = Vec::new();
         for row in namespace_data.rows {
-            proofs.push(row.proof);
+            if row.proof.is_of_presence() {
+                proofs.push(row.proof);
+            }
         }
 
         println!("Got NamespaceProofs, total: {}", proofs.len());


### PR DESCRIPTION
## Overview

Adds defensive checks in the block prover circuit against absence proofs, ensuring that only inclusion proofs can be used.
This prevents an error I saw present itself due to some inconsistencies returned from the `share.GetNamespaceData` rpc on celestia-node. 

Yesterday, when running the prover service I noticed that on occasion I would get an `AbsenceProof` returned instead of _no_ proofs at all. Our program does not need to deal with proofs of absence as we identify if share data exists for the namespace by using the min and max namespaces contained within the row roots of the data availability header.

I ran into the following error:
```
New block event height=631, blobs=0
Got 0 evm inputs at height 631
stderr: 
stderr: thread '<unnamed>' panicked at crates/sp1/evm-exec/program/src/main.rs:112:36:
stderr: range end index 1 out of range for slice of length 0
stderr: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
prove failed: execution failed with exit code 1
```

We entered the loop in the case where no blob data was provided and hit an index out of range error.
This PR addresses this by adjust our calling code to only provide proofs of presence, and anyone attempting to provide a proof of absence to the circuit will be presented with an error.