### PR TITLE
chore: mv from_env to ClientConfig type

### DIFF
--- a/crates/celestia-grpc-client/src/bin/client.rs
+++ b/crates/celestia-grpc-client/src/bin/client.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 use celestia_grpc_client::proto::celestia::zkism::v1::{QueryIsmRequest, QueryIsmsRequest};
+use celestia_grpc_client::types::ClientConfig;
 use celestia_grpc_client::{CelestiaIsmClient, MsgRemoteTransfer, StateInclusionProofMsg, StateTransitionProofMsg};
 use clap::{Parser, Subcommand};
 use tracing::{info, Level};
@@ -82,8 +83,8 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    // Create client from environment variables
-    let client = CelestiaIsmClient::from_env().await?;
+    let config = ClientConfig::from_env()?;
+    let client = CelestiaIsmClient::new(config).await?;
 
     match &cli.command {
         Commands::StateTransition {

--- a/crates/celestia-grpc-client/src/client.rs
+++ b/crates/celestia-grpc-client/src/client.rs
@@ -22,14 +22,8 @@ pub struct CelestiaIsmClient {
 
 impl CelestiaIsmClient {
     /// Create a new Celestia proof client
-    pub async fn new(mut config: ClientConfig) -> Result<Self> {
+    pub async fn new(config: ClientConfig) -> Result<Self> {
         debug!("Creating Celestia proof client with endpoint: {}", config.grpc_endpoint);
-
-        // Derive and cache the signer address if not already set
-        if config.signer_address.is_empty() {
-            config.signer_address = ClientConfig::derive_signer_address(&config.private_key_hex)?;
-            debug!("Derived signer address: {}", config.signer_address);
-        }
 
         // optional: set timeouts, concurrency limits, TLS, etc.
         let endpoint = Endpoint::from_shared(config.grpc_endpoint.clone())?

--- a/crates/celestia-grpc-client/src/client.rs
+++ b/crates/celestia-grpc-client/src/client.rs
@@ -53,33 +53,6 @@ impl CelestiaIsmClient {
         })
     }
 
-    /// Create a client from environment variables
-    pub async fn from_env() -> Result<Self> {
-        let config = ClientConfig {
-            grpc_endpoint: std::env::var("CELESTIA_GRPC_ENDPOINT")
-                .unwrap_or_else(|_| "http://localhost:9090".to_string()),
-            private_key_hex: std::env::var("CELESTIA_PRIVATE_KEY").map_err(|_| {
-                IsmClientError::Configuration("CELESTIA_PRIVATE_KEY environment variable not set".to_string())
-            })?,
-            signer_address: String::new(), // Will be derived in new()
-            chain_id: std::env::var("CELESTIA_CHAIN_ID").unwrap_or_else(|_| "celestia-zkevm-testnet".to_string()),
-            gas_price: std::env::var("CELESTIA_GAS_PRICE")
-                .unwrap_or_else(|_| "1000".to_string())
-                .parse()
-                .map_err(|_| IsmClientError::Configuration("Invalid CELESTIA_GAS_PRICE".to_string()))?,
-            max_gas: std::env::var("CELESTIA_MAX_GAS")
-                .unwrap_or_else(|_| "200000".to_string())
-                .parse()
-                .map_err(|_| IsmClientError::Configuration("Invalid CELESTIA_MAX_GAS".to_string()))?,
-            confirmation_timeout: std::env::var("CELESTIA_CONFIRMATION_TIMEOUT")
-                .unwrap_or_else(|_| "60".to_string())
-                .parse()
-                .map_err(|_| IsmClientError::Configuration("Invalid CELESTIA_CONFIRMATION_TIMEOUT".to_string()))?,
-        };
-
-        Self::new(config).await
-    }
-
     /// Get the gRPC tx client reference for direct access to Lumina functionality
     pub fn tx_client(&self) -> &GrpcClient {
         &self.tx_client
@@ -154,7 +127,7 @@ impl CelestiaIsmClient {
             }
             Err(e) => {
                 warn!("Failed to submit {} message: {}", message_type, e);
-                Err(IsmClientError::SubmissionFailed(format!(
+                Err(IsmClientError::TxFailed(format!(
                     "Failed to submit {message_type}: {e}"
                 )))
             }

--- a/crates/celestia-grpc-client/src/error.rs
+++ b/crates/celestia-grpc-client/src/error.rs
@@ -18,8 +18,8 @@ pub enum IsmClientError {
     #[error("Client configuration error: {0}")]
     Configuration(String),
 
-    #[error("Proof submission failed: {0}")]
-    SubmissionFailed(String),
+    #[error("Tx submission failed: {0}")]
+    TxFailed(String),
 
     #[error("Lumina gRPC error: {0}")]
     LuminaGrpc(#[from] anyhow::Error),

--- a/crates/e2e/src/bin/e2e.rs
+++ b/crates/e2e/src/bin/e2e.rs
@@ -1,5 +1,6 @@
 use alloy_primitives::{FixedBytes, hex::FromHex};
 use alloy_provider::ProviderBuilder;
+use celestia_grpc_client::types::ClientConfig;
 use celestia_grpc_client::{
     MsgProcessMessage, MsgSubmitMessages, MsgUpdateZkExecutionIsm, QueryIsmRequest, client::CelestiaIsmClient,
 };
@@ -22,7 +23,8 @@ async fn main() {
     dotenvy::dotenv().ok();
 
     // instantiate ISM client for submitting payloads and querying state
-    let ism_client = CelestiaIsmClient::from_env().await.unwrap();
+    let config = ClientConfig::from_env().expect("failed to create celestia client config");
+    let ism_client = CelestiaIsmClient::new(config).await.unwrap();
 
     let resp = ism_client
         .ism(QueryIsmRequest { id: ISM_ID.to_string() })


### PR DESCRIPTION
## Overview

Minor cleanup / housekeeping.

Moves the `from_env` fn directly to the `ClientConfig` and derives the address upon creation, avoiding the need for mutable config in client constructor.